### PR TITLE
Remove unnecessary steps from "Compile Examples" CI workflow

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -46,14 +46,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: '3.x'
-      
-      - name: Install nrfutil
-        run: pip3 install adafruit-nrfutil
 
       # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
       - name: Checkout ArduinoCore-API

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -52,10 +52,9 @@ jobs:
         with:
           fqbn: ${{ matrix.board.fqbn }}
           platforms: |
+            # Use Board Manager to install the latest release of Arduino mbed Boards to get the toolchain
             - source-url: "https://electroniccats.github.io/Arduino_Boards_Index/package_electroniccats_index.json"
               name: "electroniccats:mbed"
-            # Use Board Manager to install the latest release of Arduino mbed Boards to get the toolchain
-            - name: "electroniccats:mbed"
             # Overwrite the Board Manager installation with the local platform
             - source-path: "./"
               name: "electroniccats:mbed"

--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -47,19 +47,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      # The source files are in a subfolder of the ArduinoCore-API repository, so it's not possible to clone it directly to the final destination in the core
-      - name: Checkout ArduinoCore-API
-        uses: actions/checkout@v2
-        with:
-          repository: arduino/ArduinoCore-API
-          path: ArduinoCore-API
-      
-      - name: Remove old symlink to api
-        run: rm -rf "$GITHUB_WORKSPACE/cores/arduino/api"
-        
-      - name: Install ArduinoCore-API
-        run: mv "$GITHUB_WORKSPACE/ArduinoCore-API/api" "$GITHUB_WORKSPACE/cores/arduino" 
-
       - name: Compile examples
         uses: arduino/actions/libraries/compile-examples@master
         with:


### PR DESCRIPTION
The "Compile Examples" GitHub Actions workflow contained some unnecessary steps. In addition to being not ideal from a maintenance and efficiency standpoint, the configuration was actually causing the workflow to fail.